### PR TITLE
straekn_nr i t_5802_fac_li

### DIFF
--- a/src/Upgrade_2_6_0_2_to_2_6_0_2B/01_upgrade_2_6_0_2_to_2_6_0_2A.sql
+++ b/src/Upgrade_2_6_0_2_to_2_6_0_2B/01_upgrade_2_6_0_2_to_2_6_0_2A.sql
@@ -47,6 +47,7 @@ SELECT
   t.uk_l_beskr,
   t.d_k_beskr,
   t.d_l_beskr,
+  t.straekn_nr,
   t.ansvar_org,
   t.kontak_ved,
   t.betaling_k,


### PR DESCRIPTION
I patch 01_upgrade_2_6_0_2_to_2_6_0_2A.sql var feltet straekn_nr kun tilføjet tabellen og ikke viewet